### PR TITLE
Fix wonky CSV and add comparer tool

### DIFF
--- a/bin/search_result_comparer
+++ b/bin/search_result_comparer
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/search_result_comparer'
+
+if ARGV.length != 2
+  $stderr.puts "Usage: #{$0} before.csv after.csv"
+  exit 1
+end
+
+SearchResultComparer.new.compare(*ARGV)

--- a/lib/search_result_comparer.rb
+++ b/lib/search_result_comparer.rb
@@ -1,0 +1,39 @@
+require "csv"
+
+class SearchResultComparer
+  def compare(before_filename, after_filename)
+    before = CSV.read(before_filename)
+    after = CSV.read(after_filename)
+    headers = before.shift
+    after.shift
+
+    before_results = {}
+
+    before.each do |val|
+      row_hash = row_to_hash(headers, val)
+      key = [row_hash["query"], row_hash["link"]].freeze
+      before_results[key] = row_hash["position"]
+    end
+
+    after.each do |val|
+      row_hash = row_to_hash(headers, val)
+      key = [row_hash["query"], row_hash["link"]].freeze
+
+      before = before_results[key]
+      new_value = row_hash["position"]
+      diff = new_value.to_i - before.to_i
+
+      if before.nil?
+        puts "#{key} NEW result #{new_value}"
+      elsif diff != 0
+        puts "#{key} #{diff} to #{new_value}"
+      end
+    end
+  end
+
+private
+
+  def row_to_hash(headers, row)
+    headers.zip(row).to_h
+  end
+end

--- a/lib/search_result_fetcher.rb
+++ b/lib/search_result_fetcher.rb
@@ -23,26 +23,41 @@ class SearchResultFetcher
       results = response["results"]
 
       results.each_with_index do |result, i|
-        result.reject! {|key| rejected_keys.include?(key)}
 
         if first
-          csv << ['query', 'position'] + result.keys
+          csv << ['query', 'position'] + columns
           first = false
         end
 
-        csv << [q, i + 1] + present(result.values)
+        csv << [q, i + 1] + present(result)
       end
     end
   end
 
 private
 
-  def rejected_keys
-    ["es_score", "index"]
+  def columns
+    %w(
+      description
+      display_type
+      document_series
+      format
+      link
+      organisations
+      public_timestamp
+      slug
+      specialist_sectors
+      title
+      topics
+      policy_areas
+      world_locations
+    )
   end
 
-  def present(values)
-    values.map(&method(:present_value))
+  def present(result)
+    columns.map do |field_name|
+      present_value(result[field_name])
+    end
   end
 
   def present_value(value)


### PR DESCRIPTION
Rummager doesn't always return every field, so naively transforming the objects
it returns into arrays leads to uneven rows in the resulting CSV that isn't very useful.

Also added a script to tell us exactly which results have moved up/down, so that when there is a change, we can easily see what the impact is.

https://trello.com/c/EYXNHkyr/524-upgrade-elasticsearch-to-a-newer-version-m
