### PR TITLE
Change all instances of unified_search to search

### DIFF
--- a/lib/search_result_fetcher.rb
+++ b/lib/search_result_fetcher.rb
@@ -17,7 +17,7 @@ class SearchResultFetcher
 
       response = JSON(
         RestClient.get(
-          @rummager_url + '/unified_search.json', {:params => {q: q, count: 100}}
+          @rummager_url + '/search.json', {:params => {q: q, count: 100}}
         )
       )
       results = response["results"]


### PR DESCRIPTION
This commit changes all instances of unified_search to search when accessing rummager. This provides consistency between the internal and external APIs in terms of naming.

Trello: https://trello.com/c/cj8UX2jX
